### PR TITLE
Fix unit test failures

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,50 @@
+---
+
+stages:
+  - test
+
+flake8:
+  stage: test
+  image: 'python:3.6'
+  tags:
+    - docker
+  before_script:
+    - python --version
+    - pip install tox
+    - mkdir -p report/lint
+  script:
+    - make lint 
+  artifacts:
+    paths:
+      - report/lint
+
+unittest:
+  stage: test 
+  image: 'python:3.6'
+  tags:
+    - docker
+  before_script:
+    - python --version
+    - pip install tox
+    - mkdir -p report/unit
+  script:
+    - make unittest
+  coverage: '/^TOTAL.+?(\d+\%)$/'
+  artifacts:
+    paths:
+      - report/unit
+
+functional:
+    stage: test
+    tags:
+        - lxd
+    before_script:
+        - git submodule sync --recursive
+        - git submodule update --init --recursive
+        - apt-get install -y tox make
+        - snap install juju --classic || true
+        - snap install juju --classic
+        - snap install charm --classic
+        - juju bootstrap localhost
+    script:
+        - JUJU_REPOSITORY=/tmp/juju make functional

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "layers/layer-version"]
 	path = layers/layer-version
-	url = git@github.com:chris-sanders/layer-version.git
+	url = https://github.com/alchemy-charmers/layer-version.git
 [submodule "interfaces/interface-reverseproxy"]
 	path = interfaces/interface-reverseproxy
 	url = https://github.com/pirate-charmers/interface-reverseproxy.git

--- a/lib/libwireguard.py
+++ b/lib/libwireguard.py
@@ -88,7 +88,7 @@ class WireguardHelper:
 
         host.service('stop', self.service_name)
         peers_string = base64.b64decode(self.charm_config["peers"])
-        peers_yaml = yaml.load(peers_string)
+        peers_yaml = yaml.safe_load(peers_string)
         context = {
             "private_key": self.kv.get("private_key"),
             "listen_port": self.charm_config["listen-port"],

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -12,7 +12,7 @@ def mock_hookenv_config(monkeypatch):
 
     def mock_config():
         cfg = {}
-        yml = yaml.load(open("./config.yaml"))
+        yml = yaml.safe_load(open("./config.yaml"))
 
         # Load all defaults
         for key, value in yml["options"].items():
@@ -154,6 +154,9 @@ def wh(
     wh.cfg_file = str(tmpdir.join("/wg0.cfg"))
     wh.sysctl_file = str(tmpdir.join("99-sysctl.conf"))
     shutil.copy("./tests/unit/99-sysctl.conf", wh.sysctl_file)
+    wh.key_dir = str(tmpdir)
+    wh.private_key_file = str(tmpdir.join("/privatekey"))
+    wh.public_key_file = str(tmpdir.join("/publickey"))
 
     with open("./tests/unit/peers.yaml", "rb") as peers:
         peers_options = base64.b64encode(peers.read()).decode("utf-8")

--- a/tox.ini
+++ b/tox.ini
@@ -78,3 +78,4 @@ markers =
     deploy: mark deployment tests to allow running w/o redeploy
 filterwarnings = 
     ignore::DeprecationWarning
+junit_family = legacy


### PR DESCRIPTION
 * Mock key files to prevent reading them from the filesystem
 * Set junit_family for pytest
 * use safe_load for yaml loading

You wouldn't have seen the key file failure unless you tried to run the tests on a system that has wireguard installed. The unit test was actually trying to move them into the unitdb but file permissions wouldn't let it :)

Others are just simple changes to clean up warnings.